### PR TITLE
通过使用如下文所示的新版Connection profiles指令，以解决 py2neo 2021.2.3 编译报错问题

### DIFF
--- a/build_medicalgraph.py
+++ b/build_medicalgraph.py
@@ -12,11 +12,12 @@ class MedicalGraph:
     def __init__(self):
         cur_dir = '/'.join(os.path.abspath(__file__).split('/')[:-1])
         self.data_path = os.path.join(cur_dir, 'data/medical.json')
-        self.g = Graph(
-            host="127.0.0.1",  # neo4j 搭载服务器的ip地址，ifconfig可获取到
-            http_port=7474,  # neo4j 服务器监听的端口号
-            user="lhy",  # 数据库user name，如果没有更改过，应该是neo4j
-            password="lhy123")
+        # self.g = Graph(
+        #     host="127.0.0.1",  # neo4j 搭载服务器的ip地址，ifconfig可获取到
+        #     http_port=7474,  # neo4j 服务器监听的端口号
+        #     user="test",  # 数据库user name，如果没有更改过，应该是neo4j
+        #     password="test")
+        self.g = Graph('http://localhost:7474/', auth=("neo4j", "123456"))
 
     '''读取文件'''
     def read_nodes(self):


### PR DESCRIPTION
self.g = Graph('http://localhost:7474/', auth=("neo4j", "123456"))
解决ValueError: The following settings are not supported: {'http_port': 7474}问题